### PR TITLE
Batch mmr proof generation

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1678,6 +1678,32 @@ impl_runtime_apis! {
 			let node = mmr::DataOrHash::Data(leaf.into_opaque_leaf());
 			pallet_mmr::verify_leaf_proof::<mmr::Hashing, _>(root, node, proof)
 		}
+
+		fn generate_batch_proof(leaf_indices: Vec<pallet_mmr::primitives::LeafIndex>)
+			-> Result<(Vec<(mmr::EncodableOpaqueLeaf, pallet_mmr::primitives::LeafIndex)>, mmr::BatchProof<mmr::Hash>), mmr::Error>
+		{
+			Mmr::generate_batch_proof(leaf_indices)
+				.map(|(leaves, proof)| (leaves.into_iter().map(|(pos, leaf)| (mmr::EncodableOpaqueLeaf::from_leaf(&leaf), pos)).collect(), proof))
+		}
+
+		fn verify_batch_proof(leaves: Vec<mmr::EncodableOpaqueLeaf>, proof: mmr::BatchProof<mmr::Hash>)
+			-> Result<(), mmr::Error>
+		{
+			let leaf = leaves.into_iter().map(|leaf|
+				leaf.into_opaque_leaf()
+				.try_decode()
+				.ok_or(mmr::Error::Verify)).collect::<Result<Vec<mmr::Leaf >>, mmr::Error>()?;
+			Mmr::verify_leaves(leaf, proof)
+		}
+
+		fn verify_batch_proof_stateless(
+			root: mmr::Hash,
+			leaves: Vec<mmr::EncodableOpaqueLeaf>,
+			proof: mmr::BatchProof<mmr::Hash>
+		) -> Result<(), mmr::Error> {
+			let nodes = leaves.into_iter().map(|leaf|mmr::DataOrHash::Data(leaf.into_opaque_leaf())).collect();
+			pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(root, nodes, proof)
+		}
 	}
 
 	impl sp_session::SessionKeys<Block> for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1683,17 +1683,17 @@ impl_runtime_apis! {
 			-> Result<(Vec<(mmr::EncodableOpaqueLeaf, pallet_mmr::primitives::LeafIndex)>, mmr::BatchProof<mmr::Hash>), mmr::Error>
 		{
 			Mmr::generate_batch_proof(leaf_indices)
-				.map(|(leaves, proof)| (leaves.into_iter().map(|(pos, leaf)| (mmr::EncodableOpaqueLeaf::from_leaf(&leaf), pos)).collect(), proof))
+				.map(|(leaves, proof)| (leaves.into_iter().map(|(leaf, pos)| (mmr::EncodableOpaqueLeaf::from_leaf(&leaf), pos)).collect(), proof))
 		}
 
 		fn verify_batch_proof(leaves: Vec<mmr::EncodableOpaqueLeaf>, proof: mmr::BatchProof<mmr::Hash>)
 			-> Result<(), mmr::Error>
 		{
-			let leaf = leaves.into_iter().map(|leaf|
+			let leaves = leaves.into_iter().map(|leaf|
 				leaf.into_opaque_leaf()
 				.try_decode()
-				.ok_or(mmr::Error::Verify)).collect::<Result<Vec<mmr::Leaf >>, mmr::Error>()?;
-			Mmr::verify_leaves(leaf, proof)
+				.ok_or(mmr::Error::Verify)).collect::<Result<Vec<mmr::Leaf>, mmr::Error>>()?;
+			Mmr::verify_leaves(leaves, proof)
 		}
 
 		fn verify_batch_proof_stateless(

--- a/frame/merkle-mountain-range/primitives/src/lib.rs
+++ b/frame/merkle-mountain-range/primitives/src/lib.rs
@@ -292,6 +292,17 @@ pub struct Proof<Hash> {
 	pub items: Vec<Hash>,
 }
 
+/// A MMR proof data for a group of leaves.
+#[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq)]
+pub struct BatchProof<Hash> {
+	/// The indices of the leaves the proof is for.
+	pub leaf_indices: Vec<LeafIndex>,
+	/// Number of leaves in MMR, when the proof was generated.
+	pub leaf_count: NodeIndex,
+	/// Proof elements (hashes of siblings of inner nodes on the path to the leaf).
+	pub items: Vec<Hash>,
+}
+
 /// Merkle Mountain Range operation error.
 #[derive(RuntimeDebug, codec::Encode, codec::Decode, PartialEq, Eq)]
 pub enum Error {
@@ -428,6 +439,26 @@ sp_api::decl_runtime_apis! {
 		///
 		/// The leaf data is expected to be encoded in it's compact form.
 		fn verify_proof_stateless(root: Hash, leaf: EncodableOpaqueLeaf, proof: Proof<Hash>)
+			-> Result<(), Error>;
+
+		/// Generate MMR proof for a series of leaves under given indices.
+		fn generate_batch_proof(leaf_indices: Vec<LeafIndex>) -> Result<(Vec<(EncodableOpaqueLeaf, LeafIndex)>, BatchProof<Hash>), Error>;
+
+		/// Verify MMR proof against on-chain MMR for a batch of leaves.
+		///
+		/// Note this function will use on-chain MMR root hash and check if the proof
+		/// matches the hash.
+		/// Leaves must be sorted in same order as the leaf indices in the proof
+		fn verify_batch_proof(leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>) -> Result<(), Error>;
+
+		/// Verify MMR proof against given root hash or a batch of leaves.
+		///
+		/// Note this function does not require any on-chain storage - the
+		/// proof is verified against given MMR root hash.
+		///
+		/// The leaf data is expected to be encoded in it's compact form.
+		/// Leaves must be sorted in same order as the leaf indices in the proof
+		fn verify_batch_proof_stateless(root: Hash, leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>)
 			-> Result<(), Error>;
 	}
 }

--- a/frame/merkle-mountain-range/primitives/src/lib.rs
+++ b/frame/merkle-mountain-range/primitives/src/lib.rs
@@ -448,8 +448,8 @@ sp_api::decl_runtime_apis! {
 		///
 		/// Note this function will use on-chain MMR root hash and check if the proof
 		/// matches the hash.
-		/// Note, the leaves should be sorted such that corresponding leaf and leaf indices have the same position
-		/// in both the `leaves` vector and the `leaf_indices` vector contained in the proof
+		/// Note, the leaves should be sorted such that corresponding leaves and leaf indices have the
+		/// same position in both the `leaves` vector and the `leaf_indices` vector contained in the [BatchProof]
 		fn verify_batch_proof(leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>) -> Result<(), Error>;
 
 		/// Verify MMR proof against given root hash or a batch of leaves.
@@ -457,8 +457,8 @@ sp_api::decl_runtime_apis! {
 		/// Note this function does not require any on-chain storage - the
 		/// proof is verified against given MMR root hash.
 		///
-		/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have the same position
-		/// in both the `leaves` vector and the `leaf_indices` vector contained in the proof
+		/// Note, the leaves should be sorted such that corresponding leaves and leaf indices have the
+		/// same position in both the `leaves` vector and the `leaf_indices` vector contained in the [BatchProof]
 		fn verify_batch_proof_stateless(root: Hash, leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>)
 			-> Result<(), Error>;
 	}

--- a/frame/merkle-mountain-range/primitives/src/lib.rs
+++ b/frame/merkle-mountain-range/primitives/src/lib.rs
@@ -448,7 +448,8 @@ sp_api::decl_runtime_apis! {
 		///
 		/// Note this function will use on-chain MMR root hash and check if the proof
 		/// matches the hash.
-		/// Leaves must be sorted in same order as the leaf indices in the proof
+		/// Note, the leaves should be sorted such that corresponding leaf and leaf indices have the same position
+		/// in both the `leaves` vector and the `leaf_indices` vector contained in the proof
 		fn verify_batch_proof(leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>) -> Result<(), Error>;
 
 		/// Verify MMR proof against given root hash or a batch of leaves.
@@ -456,8 +457,8 @@ sp_api::decl_runtime_apis! {
 		/// Note this function does not require any on-chain storage - the
 		/// proof is verified against given MMR root hash.
 		///
-		/// The leaf data is expected to be encoded in it's compact form.
-		/// Leaves must be sorted in same order as the leaf indices in the proof
+		/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have the same position
+		/// in both the `leaves` vector and the `leaf_indices` vector contained in the proof
 		fn verify_batch_proof_stateless(root: Hash, leaves: Vec<EncodableOpaqueLeaf>, proof: BatchProof<Hash>)
 			-> Result<(), Error>;
 	}

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -70,7 +70,7 @@ pub struct LeafBatchProof<BlockHash> {
 }
 
 impl<BlockHash> LeafBatchProof<BlockHash> {
-	/// Create new `LeafBatchProof` from a given vector of concrete `leaf` and `proof`.
+	/// Create new `LeafBatchProof` from a given vector of ([Leaf], [LeafIndex]) and a [BatchProof].
 	pub fn new<Leaf, MmrHash>(
 		block_hash: BlockHash,
 		leaves: Vec<(Leaf, LeafIndex)>,

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -70,7 +70,8 @@ pub struct LeafBatchProof<BlockHash> {
 }
 
 impl<BlockHash> LeafBatchProof<BlockHash> {
-	/// Create new `LeafBatchProof` from a given vector of ([Leaf], [LeafIndex]) and a [BatchProof].
+	/// Create new `LeafBatchProof` from a given vector of (`Leaf`,
+	/// [pallet_mmr_primitives::LeafIndex]) and a [pallet_mmr_primitives::BatchProof].
 	pub fn new<Leaf, MmrHash>(
 		block_hash: BlockHash,
 		leaves: Vec<(Leaf, LeafIndex)>,

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -26,7 +26,7 @@ use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
 
-use pallet_mmr_primitives::{Error as MmrError, Proof};
+use pallet_mmr_primitives::{BatchProof, Error as MmrError, Proof};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::Bytes;
@@ -57,6 +57,33 @@ impl<BlockHash> LeafProof<BlockHash> {
 	}
 }
 
+/// Retrieved MMR leaf and its proof.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LeafBatchProof<BlockHash> {
+	/// Block hash the proof was generated for.
+	pub block_hash: BlockHash,
+	/// SCALE-encoded vector of leaf index and leaf data `(LeafData, LeafIndex)`.
+	pub leaves: Bytes,
+	/// SCALE-encoded proof data. See [pallet_mmr_primitives::BatchProof].
+	pub proof: Bytes,
+}
+
+impl<BlockHash> LeafBatchProof<BlockHash> {
+	/// Create new `LeafBatchProof` from a given vector of concrete `leaf` and `proof`.
+	pub fn new<Leaf, MmrHash>(
+		block_hash: BlockHash,
+		leaves: Vec<(Leaf, LeafIndex)>,
+		proof: BatchProof<MmrHash>,
+	) -> Self
+	where
+		Leaf: Encode,
+		MmrHash: Encode,
+	{
+		Self { block_hash, leaves: Bytes(leaves.encode()), proof: Bytes(proof.encode()) }
+	}
+}
+
 /// MMR RPC methods.
 #[rpc]
 pub trait MmrApi<BlockHash> {
@@ -74,6 +101,21 @@ pub trait MmrApi<BlockHash> {
 		leaf_index: LeafIndex,
 		at: Option<BlockHash>,
 	) -> Result<LeafProof<BlockHash>>;
+
+	/// Generate MMR proof for the given leaf indices.
+	///
+	/// This method calls into a runtime with MMR pallet included and attempts to generate
+	/// MMR proof for a set of leaves at the given `leaf_indices`.
+	/// Optionally, a block hash at which the runtime should be queried can be specified.
+	///
+	/// Returns the leaves and a proof for these leaves (compact encoding, i.e. hash of
+	/// the leaves). Both parameters are SCALE-encoded.
+	#[rpc(name = "mmr_generateBatchProof")]
+	fn generate_batch_proof(
+		&self,
+		leaf_indices: Vec<LeafIndex>,
+		at: Option<BlockHash>,
+	) -> Result<LeafBatchProof<BlockHash>>;
 }
 
 /// An implementation of MMR specific RPC methods.
@@ -116,6 +158,28 @@ where
 			.map_err(mmr_error_into_rpc_error)?;
 
 		Ok(LeafProof::new(block_hash, leaf, proof))
+	}
+
+	fn generate_batch_proof(
+		&self,
+		leaf_indices: Vec<LeafIndex>,
+		at: Option<<Block as BlockT>::Hash>,
+	) -> Result<LeafBatchProof<<Block as BlockT>::Hash>> {
+		let api = self.client.runtime_api();
+		let block_hash = at.unwrap_or_else(||
+			// If the block hash is not supplied assume the best block.
+			self.client.info().best_hash);
+
+		let (leaves, proof) = api
+			.generate_batch_proof_with_context(
+				&BlockId::hash(block_hash),
+				sp_core::ExecutionContext::OffchainCall(None),
+				leaf_indices,
+			)
+			.map_err(runtime_error_into_rpc_error)?
+			.map_err(mmr_error_into_rpc_error)?;
+
+		Ok(LeafBatchProof::new(block_hash, leaves, proof))
 	}
 }
 

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -244,6 +244,27 @@ mod tests {
 	}
 
 	#[test]
+	fn should_serialize_leaf_batch_proof() {
+		// given
+		let leaf = vec![1_u8, 2, 3, 4];
+		let proof = BatchProof {
+			leaf_indices: vec![1],
+			leaf_count: 9,
+			items: vec![H256::repeat_byte(1), H256::repeat_byte(2)],
+		};
+
+		let leaf_proof = LeafBatchProof::new(H256::repeat_byte(0), vec![(leaf, 1)], proof);
+
+		// when
+		let actual = serde_json::to_string(&leaf_proof).unwrap();
+		// then
+		assert_eq!(
+			actual,
+			r#"{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","leaves":"0x0410010203040100000000000000","proof":"0x04010000000000000009000000000000000801010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202"}"#
+		);
+	}
+
+	#[test]
 	fn should_deserialize_leaf_proof() {
 		// given
 		let expected = LeafProof {
@@ -264,6 +285,33 @@ mod tests {
 			"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
 			"leaf":"0x1001020304",
 			"proof":"0x010000000000000009000000000000000801010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202"
+		}"#).unwrap();
+
+		// then
+		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn should_deserialize_leaf_batch_proof() {
+		// given
+		let expected = LeafBatchProof {
+			block_hash: H256::repeat_byte(0),
+			leaves: Bytes(vec![(vec![1_u8, 2, 3, 4], 1)].encode()),
+			proof: Bytes(
+				BatchProof {
+					leaf_indices: vec![1],
+					leaf_count: 9,
+					items: vec![H256::repeat_byte(1), H256::repeat_byte(2)],
+				}
+				.encode(),
+			),
+		};
+
+		// when
+		let actual: LeafBatchProof<H256> = serde_json::from_str(r#"{
+			"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+			"leaves":"0x04100102030401000000",
+			"proof":"0x04010000000000000009000000000000000801010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202"
 		}"#).unwrap();
 
 		// then

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -228,6 +228,29 @@ where
 	}
 }
 
+/// Stateless MMR proof verification for batch of leaves.
+///
+/// This function can be used to verify received MMR proof (`proof`)
+/// for given leaf data (`leaf`) against a known MMR root hash (`root`).
+///
+/// The verification does not require any storage access.
+pub fn verify_leaves_proof<H, L>(
+	root: H::Output,
+	leaves: Vec<mmr::Node<H, L>>,
+	proof: primitives::BatchProof<H::Output>,
+) -> Result<(), primitives::Error>
+where
+	H: traits::Hash,
+	L: primitives::FullLeaf,
+{
+	let is_valid = mmr::verify_leaves_proof::<H, L>(root, leaves, proof)?;
+	if is_valid {
+		Ok(())
+	} else {
+		Err(primitives::Error::Verify.log_debug(("The proof is incorrect.", root)))
+	}
+}
+
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn offchain_key(pos: NodeIndex) -> sp_std::prelude::Vec<u8> {
 		(T::INDEXING_PREFIX, pos).encode()
@@ -244,6 +267,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<(LeafOf<T, I>, primitives::Proof<<T as Config<I>>::Hash>), primitives::Error> {
 		let mmr: ModuleMmr<mmr::storage::OffchainStorage, T, I> = mmr::Mmr::new(Self::mmr_leaves());
 		mmr.generate_proof(leaf_index)
+	}
+
+	/// Generate a MMR proof for the given `leaf_indices`.
+	///
+	/// Note this method can only be used from an off-chain context
+	/// (Offchain Worker or Runtime API call), since it requires
+	/// all the leaves to be present.
+	/// It may return an error or panic if used incorrectly.
+	pub fn generate_batch_proof(
+		leaf_indices: Vec<NodeIndex>,
+	) -> Result<
+		(Vec<(LeafOf<T, I>, NodeIndex)>, primitives::BatchProof<<T as Config<I>>::Hash>),
+		primitives::Error,
+	> {
+		let mmr: ModuleMmr<mmr::storage::OffchainStorage, T, I> = mmr::Mmr::new(Self::mmr_leaves());
+		mmr.generate_batch_proof(leaf_indices)
 	}
 
 	/// Verify MMR proof for given `leaf`.
@@ -266,6 +305,33 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		let mmr: ModuleMmr<mmr::storage::OffchainStorage, T, I> = mmr::Mmr::new(proof.leaf_count);
 		let is_valid = mmr.verify_leaf_proof(leaf, proof)?;
+		if is_valid {
+			Ok(())
+		} else {
+			Err(primitives::Error::Verify.log_debug("The proof is incorrect."))
+		}
+	}
+
+	/// Verify MMR proof for given `leaves`.
+	///
+	/// This method is safe to use within the runtime code.
+	/// It will return `Ok(())` if the proof is valid
+	/// and an `Err(..)` if MMR is inconsistent (some leaves are missing)
+	/// or the proof is invalid.
+	pub fn verify_leaves(
+		leaves: Vec<LeafOf<T, I>>,
+		proof: primitives::BatchProof<<T as Config<I>>::Hash>,
+	) -> Result<(), primitives::Error> {
+		if proof.leaf_count > Self::mmr_leaves() ||
+			proof.leaf_count == 0 ||
+			proof.items.len() as u32 > mmr::utils::NodesUtils::new(proof.leaf_count).depth()
+		{
+			return Err(primitives::Error::Verify
+				.log_debug("The proof has incorrect number of leaves or proof items."))
+		}
+
+		let mmr: ModuleMmr<mmr::storage::OffchainStorage, T, I> = mmr::Mmr::new(proof.leaf_count);
+		let is_valid = mmr.verify_leaves_proof(leaves, proof)?;
 		if is_valid {
 			Ok(())
 		} else {

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -71,6 +71,8 @@ mod tests;
 
 pub use pallet::*;
 pub use pallet_mmr_primitives::{self as primitives, NodeIndex};
+#[cfg(not(feature = "std"))]
+use sp_std::prelude::Vec;
 
 pub trait WeightInfo {
 	fn on_initialize(peaks: NodeIndex) -> Weight;

--- a/frame/merkle-mountain-range/src/mmr/mmr.rs
+++ b/frame/merkle-mountain-range/src/mmr/mmr.rs
@@ -49,8 +49,9 @@ where
 }
 
 /// Stateless verification of the proof for a batch of leaves.
-/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have the
-/// same position in both the `leaves` vector and the `leaf_indices` vector contained in the proof
+/// Note, the leaves should be sorted such that corresponding leaves and leaf indices have the
+/// same position in both the `leaves` vector and the `leaf_indices` vector contained in the
+/// [primitives::BatchProof]
 pub fn verify_leaves_proof<H, L>(
 	root: H::Output,
 	leaves: Vec<Node<H, L>>,
@@ -122,9 +123,9 @@ where
 	}
 
 	/// Verify proof of a single leaf.
-	/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have
+	/// Note, the leaves should be sorted such that corresponding leaves and leaf indices have
 	/// the same position in both the `leaves` vector and the `leaf_indices` vector contained in the
-	/// proof
+	/// [primitives::BatchProof]
 	pub fn verify_leaves_proof(
 		&self,
 		leaves: Vec<L>,

--- a/frame/merkle-mountain-range/src/mmr/mmr.rs
+++ b/frame/merkle-mountain-range/src/mmr/mmr.rs
@@ -49,6 +49,8 @@ where
 }
 
 /// Stateless verification of the proof for a batch of leaves.
+/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have the
+/// same position in both the `leaves` vector and the `leaf_indices` vector contained in the proof
 pub fn verify_leaves_proof<H, L>(
 	root: H::Output,
 	leaves: Vec<Node<H, L>>,
@@ -120,8 +122,9 @@ where
 	}
 
 	/// Verify proof of a single leaf.
-	/// Note, the leaves should be sorted such that the order of leaves is equivalent to the order
-	/// of leaf indices in the proof
+	/// Note, the leaves should be sorted such that each corresponding leafs and leaf indices have
+	/// the same position in both the `leaves` vector and the `leaf_indices` vector contained in the
+	/// proof
 	pub fn verify_leaves_proof(
 		&self,
 		leaves: Vec<L>,

--- a/frame/merkle-mountain-range/src/mmr/mmr.rs
+++ b/frame/merkle-mountain-range/src/mmr/mmr.rs
@@ -25,7 +25,7 @@ use crate::{
 	Config, HashingOf,
 };
 #[cfg(not(feature = "std"))]
-use sp_std::vec;
+use sp_std::{prelude::Vec, vec};
 
 /// Stateless verification of the leaf proof.
 pub fn verify_leaf_proof<H, L>(
@@ -45,6 +45,33 @@ where
 		proof.items.into_iter().map(Node::Hash).collect(),
 	);
 	p.verify(Node::Hash(root), vec![(leaf_position, leaf)])
+		.map_err(|e| Error::Verify.log_debug(e))
+}
+
+/// Stateless verification of the proof for a batch of leaves.
+pub fn verify_leaves_proof<H, L>(
+	root: H::Output,
+	leaves: Vec<Node<H, L>>,
+	proof: primitives::BatchProof<H::Output>,
+) -> Result<bool, Error>
+where
+	H: sp_runtime::traits::Hash,
+	L: primitives::FullLeaf,
+{
+	let size = NodesUtils::new(proof.leaf_count).size();
+
+	let leaves_and_position = proof
+		.leaf_indices
+		.into_iter()
+		.map(|index| mmr_lib::leaf_index_to_pos(index))
+		.zip(leaves.into_iter())
+		.collect();
+
+	let p = mmr_lib::MerkleProof::<Node<H, L>, Hasher<H, L>>::new(
+		size,
+		proof.items.into_iter().map(Node::Hash).collect(),
+	);
+	p.verify(Node::Hash(root), leaves_and_position)
 		.map_err(|e| Error::Verify.log_debug(e))
 }
 
@@ -90,6 +117,28 @@ where
 		let root = self.mmr.get_root().map_err(|e| Error::GetRoot.log_error(e))?;
 		p.verify(root, vec![(position, Node::Data(leaf))])
 			.map_err(|e| Error::Verify.log_debug(e))
+	}
+
+	/// Verify proof of a single leaf.
+	/// Note, the leaves should be sorted such that the order of leaves is equivalent to the order
+	/// of leaf indices in the proof
+	pub fn verify_leaves_proof(
+		&self,
+		leaves: Vec<L>,
+		proof: primitives::BatchProof<<T as Config<I>>::Hash>,
+	) -> Result<bool, Error> {
+		let p = mmr_lib::MerkleProof::<NodeOf<T, I, L>, Hasher<HashingOf<T, I>, L>>::new(
+			self.mmr.mmr_size(),
+			proof.items.into_iter().map(Node::Hash).collect(),
+		);
+		let leaves_and_position = proof
+			.leaf_indices
+			.into_iter()
+			.map(|index| mmr_lib::leaf_index_to_pos(index))
+			.zip(leaves.into_iter().map(|leaf| Node::Data(leaf)))
+			.collect();
+		let root = self.mmr.get_root().map_err(|e| Error::GetRoot.log_error(e))?;
+		p.verify(root, leaves_and_position).map_err(|e| Error::Verify.log_debug(e))
 	}
 
 	/// Return the internal size of the MMR (number of nodes).
@@ -158,5 +207,41 @@ where
 				items: p.proof_items().iter().map(|x| x.hash()).collect(),
 			})
 			.map(|p| (leaf, p))
+	}
+
+	/// Generate a proof for given leaf indices.
+	///
+	/// Proof generation requires all the nodes (or their hashes) to be available in the storage.
+	/// (i.e. you can't run the function in the pruned storage).
+	pub fn generate_batch_proof(
+		&self,
+		leaf_indices: Vec<NodeIndex>,
+	) -> Result<(Vec<(L, NodeIndex)>, primitives::BatchProof<<T as Config<I>>::Hash>), Error> {
+		let positions = leaf_indices
+			.iter()
+			.map(|index| mmr_lib::leaf_index_to_pos(*index))
+			.collect::<Vec<_>>();
+		let store = <Storage<OffchainStorage, T, I, L>>::default();
+		let leaves = positions
+			.iter()
+			.map(|pos| match mmr_lib::MMRStore::get_elem(&store, *pos) {
+				Ok(Some(Node::Data(leaf))) => Ok(leaf),
+				e => Err(Error::LeafNotFound.log_debug(e)),
+			})
+			.collect::<Result<Vec<_>, Error>>()?
+			.into_iter()
+			.zip(leaf_indices.iter().cloned())
+			.collect::<Vec<_>>();
+
+		let leaf_count = self.leaves;
+		self.mmr
+			.gen_proof(positions)
+			.map_err(|e| Error::GenerateProof.log_error(e))
+			.map(|p| primitives::BatchProof {
+				leaf_indices,
+				leaf_count,
+				items: p.proof_items().iter().map(|x| x.hash()).collect(),
+			})
+			.map(|p| (leaves, p))
 	}
 }

--- a/frame/merkle-mountain-range/src/mmr/mod.rs
+++ b/frame/merkle-mountain-range/src/mmr/mod.rs
@@ -22,7 +22,7 @@ pub mod utils;
 use crate::primitives::FullLeaf;
 use sp_runtime::traits;
 
-pub use self::mmr::{verify_leaf_proof, Mmr};
+pub use self::mmr::{verify_leaf_proof, verify_leaves_proof, Mmr};
 
 /// Node type for runtime `T`.
 pub type NodeOf<T, I, L> = Node<<T as crate::Config<I>>::Hashing, L>;

--- a/frame/merkle-mountain-range/src/tests.rs
+++ b/frame/merkle-mountain-range/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{mmr::utils, mock::*, *};
 
 use frame_support::traits::OnInitialize;
 use mmr_lib::helper;
-use pallet_mmr_primitives::{Compact, Proof};
+use pallet_mmr_primitives::{BatchProof, Compact, Proof};
 use sp_core::{
 	offchain::{testing::TestOffchainExt, OffchainDbExt, OffchainWorkerExt},
 	H256,
@@ -277,6 +277,37 @@ fn should_generate_proofs_correctly() {
 }
 
 #[test]
+fn should_generate_batch_proof_correctly() {
+	let _ = env_logger::try_init();
+	let mut ext = new_test_ext();
+	// given
+	ext.execute_with(|| init_chain(7));
+	ext.persist_offchain_overlay();
+
+	// Try to generate proofs now. This requires the offchain extensions to be present
+	// to retrieve full leaf data.
+	register_offchain_ext(&mut ext);
+	ext.execute_with(|| {
+		// when generate proofs for all leaves
+		let (leaves, proof) = crate::Pallet::<Test>::generate_batch_proof(vec![0, 4, 5]).unwrap();
+
+		// then
+		assert_eq!(
+			proof,
+			BatchProof {
+				leaf_indices: vec![0, 4, 5],
+				leaf_count: 7,
+				items: vec![
+					hex("ad4cbc033833612ccd4626d5f023b9dfc50a35e838514dd1f3c86f8506728705"),
+					hex("cb24f4614ad5b2a5430344c99545b421d9af83c46fd632d70a332200884b4d46"),
+					hex("611c2174c6164952a66d985cfe1ec1a623794393e3acff96b136d198f37a648c"),
+				],
+			}
+		);
+	});
+}
+
+#[test]
 fn should_verify() {
 	let _ = env_logger::try_init();
 
@@ -298,6 +329,37 @@ fn should_verify() {
 		init_chain(7);
 		// then
 		assert_eq!(crate::Pallet::<Test>::verify_leaf(leaf, proof5), Ok(()));
+	});
+}
+
+#[test]
+fn should_verify_batch_proof() {
+	let _ = env_logger::try_init();
+
+	// Start off with chain initialisation and storing indexing data off-chain
+	// (MMR Leafs)
+	let mut ext = new_test_ext();
+	ext.execute_with(|| init_chain(7));
+	ext.persist_offchain_overlay();
+
+	// Try to generate proof now. This requires the offchain extensions to be present
+	// to retrieve full leaf data.
+	register_offchain_ext(&mut ext);
+	let (leaves, proof) = ext.execute_with(|| {
+		// when
+		crate::Pallet::<Test>::generate_batch_proof(vec![0, 4, 5]).unwrap()
+	});
+
+	ext.execute_with(|| {
+		init_chain(7);
+		// then
+		assert_eq!(
+			crate::Pallet::<Test>::verify_leaves(
+				leaves.into_iter().map(|(leaf, ..)| leaf).collect(),
+				proof
+			),
+			Ok(())
+		);
 	});
 }
 
@@ -324,6 +386,39 @@ fn verification_should_be_stateless() {
 	let leaf = crate::primitives::DataOrHash::Data(leaf);
 	assert_eq!(
 		crate::verify_leaf_proof::<<Test as Config>::Hashing, _>(root, leaf, proof5),
+		Ok(())
+	);
+}
+
+#[test]
+fn should_verify_batch_proof_statelessly() {
+	let _ = env_logger::try_init();
+
+	// Start off with chain initialisation and storing indexing data off-chain
+	// (MMR Leafs)
+	let mut ext = new_test_ext();
+	ext.execute_with(|| init_chain(7));
+	ext.persist_offchain_overlay();
+
+	// Try to generate proof now. This requires the offchain extensions to be present
+	// to retrieve full leaf data.
+	register_offchain_ext(&mut ext);
+	let (leaves, proof) = ext.execute_with(|| {
+		// when
+		crate::Pallet::<Test>::generate_batch_proof(vec![0, 4, 5]).unwrap()
+	});
+	let root = ext.execute_with(|| crate::Pallet::<Test>::mmr_root_hash());
+
+	// Verify proof without relying on any on-chain data.
+	assert_eq!(
+		crate::verify_leaves_proof::<<Test as Config>::Hashing, _>(
+			root,
+			leaves
+				.into_iter()
+				.map(|(leaf, ..)| crate::primitives::DataOrHash::Data(leaf))
+				.collect(),
+			proof
+		),
 		Ok(())
 	);
 }

--- a/frame/merkle-mountain-range/src/tests.rs
+++ b/frame/merkle-mountain-range/src/tests.rs
@@ -289,7 +289,7 @@ fn should_generate_batch_proof_correctly() {
 	register_offchain_ext(&mut ext);
 	ext.execute_with(|| {
 		// when generate proofs for all leaves
-		let (leaves, proof) = crate::Pallet::<Test>::generate_batch_proof(vec![0, 4, 5]).unwrap();
+		let (.., proof) = crate::Pallet::<Test>::generate_batch_proof(vec![0, 4, 5]).unwrap();
 
 		// then
 		assert_eq!(


### PR DESCRIPTION
This PR adds new functions to the MMR Runtime API to accept an array of leaf indexes, this would allow generating a proof for multiple leaf indices in one run if needed

Also added functions for verifying these kind of proof