### PR TITLE
Fix CI (#12297)

### DIFF
--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -107,9 +107,9 @@ pub mod pallet {
 		/// Standard collection creation is only allowed if the origin attempting it and the
 		/// collection are in this set.
 		type CreateOrigin: EnsureOriginWithArg<
-			Success = Self::AccountId,
 			Self::Origin,
 			Self::CollectionId,
+			Success = Self::AccountId,
 		>;
 
 		/// Locker trait to enable Locking mechanism downstream.


### PR DESCRIPTION
* Put type constraint at the end

Signed-off-by: Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>



✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏

Before you submit, please check that:

- [ ] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points should reviewers know?
  - Is there something left for follow-up PRs?
- [ ] **Labels:** You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github project assignment
- [ ] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.
- [ ] **Runtime Version:** You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] **Docs:** You updated any rustdocs which may need to change.
- [ ] **Polkadot Companion:** Has the PR altered the external API or interfaces used by Polkadot?
  - [ ] If so, do you have the corresponding Polkadot PR ready?
  - [ ] Optionally: Do you have a corresponding Cumulus PR?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
